### PR TITLE
Feat 19 : 작품 관련 삭제 기능

### DIFF
--- a/src/main/java/com/lit_map_BackEnd/domain/character/controller/CastController.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/character/controller/CastController.java
@@ -1,0 +1,37 @@
+package com.lit_map_BackEnd.domain.character.controller;
+
+import com.lit_map_BackEnd.common.exception.code.SuccessCode;
+import com.lit_map_BackEnd.common.exception.response.SuccessResponse;
+import com.lit_map_BackEnd.domain.character.service.CastService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/cast")
+@RequiredArgsConstructor
+public class CastController {
+
+    private final CastService castService;
+
+    @DeleteMapping("/{workId}/{versionNum}/{castName}")
+    @Operation(summary = "특정 캐릭터 삭제", description = "혹여 캐릭터를 삭제할때 이미 데이터베이스에 들어가있는것을 대비하여 삭제할 경우 삭제 API 필요")
+    public ResponseEntity<SuccessResponse> deleteCastInVersion(@PathVariable Long workId,
+                                                               @PathVariable Double versionNum,
+                                                               @PathVariable String castName) {
+        castService.deleteCastInVersion(workId, versionNum, castName);
+
+        SuccessResponse res = SuccessResponse.builder()
+                .result("삭제 성공")
+                .resultCode(SuccessCode.DELETE_SUCCESS.getStatus())
+                .resultMsg(SuccessCode.DELETE_SUCCESS.getMessage())
+                .build();
+
+        return new ResponseEntity<>(res, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/lit_map_BackEnd/domain/character/repository/CastRepository.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/character/repository/CastRepository.java
@@ -14,5 +14,7 @@ public interface CastRepository extends JpaRepository<Cast, Long> {
 
     Cast findByVersionAndName(Version version, String name);
 
+    void deleteByWorkAndVersionAndName(Work work, Version version, String name);
+
     List<Cast> findByVersion(Version version);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/character/service/CastService.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/character/service/CastService.java
@@ -12,4 +12,6 @@ public interface CastService {
     Cast insertCharacter(CastRequestDto castRequestDto);
 
     List<CastResponseDto> findCharacterByWork(Work work);
+
+    void deleteCastInVersion(Long workId, Double versionId, String name);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/character/service/CastServiceImpl.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/character/service/CastServiceImpl.java
@@ -1,10 +1,14 @@
 package com.lit_map_BackEnd.domain.character.service;
 
+import com.lit_map_BackEnd.common.exception.BusinessExceptionHandler;
+import com.lit_map_BackEnd.common.exception.code.ErrorCode;
 import com.lit_map_BackEnd.domain.character.dto.CastRequestDto;
 import com.lit_map_BackEnd.domain.character.dto.CastResponseDto;
 import com.lit_map_BackEnd.domain.character.entity.Cast;
 import com.lit_map_BackEnd.domain.character.repository.CastRepository;
+import com.lit_map_BackEnd.domain.work.entity.Version;
 import com.lit_map_BackEnd.domain.work.entity.Work;
+import com.lit_map_BackEnd.domain.work.repository.VersionRepository;
 import com.lit_map_BackEnd.domain.work.repository.WorkRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +23,7 @@ public class CastServiceImpl implements CastService {
 
     private final CastRepository castRepository;
     private final WorkRepository workRepository;
+    private final VersionRepository versionRepository;
 
     @Override
     @Transactional
@@ -71,5 +76,21 @@ public class CastServiceImpl implements CastService {
                         .contents(cast.getContents())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void deleteCastInVersion(Long workId, Double versionNum, String name) {
+        Work work = workRepository.findById(workId)
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.WORK_NOT_FOUND));
+
+        Version version = null;
+        if (versionRepository.existsByVersionNumAndWork(versionNum, work)) {
+            version = versionRepository.findByVersionNumAndWork(versionNum, work);
+        } else {
+            throw new BusinessExceptionHandler(ErrorCode.VERSION_NOT_FOUND);
+        }
+
+        castRepository.deleteByWorkAndVersionAndName(work, version, name);
     }
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/controller/VersionController.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/controller/VersionController.java
@@ -1,0 +1,37 @@
+package com.lit_map_BackEnd.domain.work.controller;
+
+import com.lit_map_BackEnd.common.exception.code.SuccessCode;
+import com.lit_map_BackEnd.common.exception.response.SuccessResponse;
+import com.lit_map_BackEnd.domain.work.service.VersionService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/version")
+@RequiredArgsConstructor
+public class VersionController {
+
+    private final VersionService versionService;
+
+    @DeleteMapping("/{workId}/{versionNum}")
+    @Operation(summary = "특정 버전 삭제", description = "특정 버전만 삭제하고 관련 캐릭터들도 같이 삭제")
+    public ResponseEntity<SuccessResponse> deleteVersionInWork(@PathVariable Long workId,
+                                                               @PathVariable Double versionNum) {
+        versionService.deleteVersion(workId, versionNum);
+
+        SuccessResponse res = SuccessResponse.builder()
+                .result("성공")
+                .resultCode(SuccessCode.DELETE_SUCCESS.getStatus())
+                .resultMsg(SuccessCode.DELETE_SUCCESS.getMessage())
+                .build();
+
+        return new ResponseEntity<>(res, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/lit_map_BackEnd/domain/work/controller/WorkController.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/controller/WorkController.java
@@ -67,4 +67,10 @@ public class WorkController {
 
         return new ResponseEntity<>(res, HttpStatus.OK);
     }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "작품 삭제", description = "작품을 삭제하고 관련 내용도 같이 삭제")
+    public ResponseEntity<SuccessResponse> deleteWork(@RequestParam Long id) {
+        return new ResponseEntity<>(null, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/controller/WorkController.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/controller/WorkController.java
@@ -70,7 +70,15 @@ public class WorkController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "작품 삭제", description = "작품을 삭제하고 관련 내용도 같이 삭제")
-    public ResponseEntity<SuccessResponse> deleteWork(@RequestParam Long id) {
-        return new ResponseEntity<>(null, HttpStatus.OK);
+    public ResponseEntity<SuccessResponse> deleteWork(@PathVariable Long id) {
+        workService.deleteWork(id);
+
+        SuccessResponse res = SuccessResponse.builder()
+                .result("성공")
+                .resultCode(SuccessCode.DELETE_SUCCESS.getStatus())
+                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
+                .build();
+
+        return new ResponseEntity<>(res, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/dto/WorkResponseDto.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/dto/WorkResponseDto.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkResponseDto {
+    private Long workId;
     private String category;
     private List<String> genre;
     private List<String> author;

--- a/src/main/java/com/lit_map_BackEnd/domain/work/entity/Version.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/entity/Version.java
@@ -29,7 +29,7 @@ public class Version extends BaseTimeEntity {
     private Work work;
 
     @Builder.Default
-    @OneToMany(mappedBy = "version")
+    @OneToMany(mappedBy = "version", cascade = CascadeType.ALL)
     private List<Cast> casts = new ArrayList<>();
 
     private Double versionNum;

--- a/src/main/java/com/lit_map_BackEnd/domain/work/repository/VersionRepository.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/repository/VersionRepository.java
@@ -11,4 +11,6 @@ public interface VersionRepository extends JpaRepository<Version, Long> {
 
     boolean existsByVersionNumAndWork(Double version, Work work);
     List<Version> findByWork(Work work);
+
+    void deleteByWorkAndVersionNum(Work work, Double versionNum);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/repository/WorkRepository.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/repository/WorkRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface WorkRepository extends JpaRepository<Work, Long> {
     boolean existsByTitle(String title);
-
     Work findByTitle(String title);
+
+    void deleteById(Long workId);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionService.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionService.java
@@ -17,4 +17,6 @@ public interface VersionService {
     Version changeVersion(Double versionNum, String versionName, Map<String, Object> relationship, Work work);
 
     VersionResponseDto findVersionByWorkAndNumber(Long workId, Double versionNum);
+
+    void deleteVersion(Long workId, Double versionNum);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionServiceImpl.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionServiceImpl.java
@@ -99,5 +99,14 @@ public class VersionServiceImpl implements VersionService{
                 .build();
     }
 
+    @Override
+    @Transactional
+    public void deleteVersion(Long workId, Double versionNum) {
+        Work work = workRepository.findById(workId)
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.WORK_NOT_FOUND));
+
+        versionRepository.deleteByWorkAndVersionNum(work, versionNum);
+    }
+
 
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkService.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkService.java
@@ -9,4 +9,6 @@ public interface WorkService {
     int saveWork(@Valid WorkRequestDto workRequestDto);
 
     WorkResponseDto getWork(Long workId);
+
+    int deleteWork();
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkService.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkService.java
@@ -10,5 +10,5 @@ public interface WorkService {
 
     WorkResponseDto getWork(Long workId);
 
-    int deleteWork();
+    void deleteWork(Long workId);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkServiceImpl.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkServiceImpl.java
@@ -233,6 +233,7 @@ public class WorkServiceImpl implements WorkService{
     }
 
     @Override
+    @Transactional
     public void deleteWork(Long workId) {
         workRepository.findById(workId)
                 .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.WORK_NOT_FOUND));

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkServiceImpl.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkServiceImpl.java
@@ -232,8 +232,17 @@ public class WorkServiceImpl implements WorkService{
                 .build();
     }
 
+    @Override
+    public void deleteWork(Long workId) {
+        workRepository.findById(workId)
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.WORK_NOT_FOUND));
+
+        workRepository.deleteById(workId);
+    }
+
+
     // 제출(true)과 수정/임시저장(false)을 구분하는 메소드
-    public Confirm checkConfirm(boolean status) {
+    private Confirm checkConfirm(boolean status) {
         if (!status) return Confirm.LOAD;
         else return Confirm.CONFIRM;
     }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkServiceImpl.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkServiceImpl.java
@@ -219,6 +219,7 @@ public class WorkServiceImpl implements WorkService{
         VersionResponseDto version = versionService.findVersionByWorkAndNumber(work.getId(), 0.1);
 
         return WorkResponseDto.builder()
+                .workId(work.getId())
                 .category(category.getName())
                 .genre(workGenresList)
                 .author(workAuthorsList)


### PR DESCRIPTION
1. 특정 작품을 삭제하였을 경우 관련 정보 모두 삭제
2. 특정 작품의 버전을 삭제하면 해당 버전과 관련 캐릭터 모두 삭제
3. 수정 혹은 제작 중 임시저장을 하였을 경우 캐릭터의 정보가 DB에 들어간다 때문에 이후 수정에서 캐릭터를 삭제하면 DB에서도 삭제 되어야 하기 때문에 캐릭터 삭제 기능 추가