### PR TITLE
Feat 27 : 롤백 테이블 제작

### DIFF
--- a/src/main/java/com/lit_map_BackEnd/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/lit_map_BackEnd/common/exception/code/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     CATEGORY_NOT_FOUND(500, "해당 카테고리는 존재하지 않습니다"),
     JSON_PARSING_ERROR(500, "JSON 데이터에 문제가 있습니다"),
     WRITER_WRONG(500, "기존의 작성자가 아닙니다"),
+    NOT_CONFIRM_VERSION(500, "아직 승인이 난 버전이 아닙니다."),
 
     // SQL 문제 발생
     INSERT_ERROR(500, "데이터 삽입 문제 발생"),

--- a/src/main/java/com/lit_map_BackEnd/common/exception/code/SuccessCode.java
+++ b/src/main/java/com/lit_map_BackEnd/common/exception/code/SuccessCode.java
@@ -8,6 +8,7 @@ public enum SuccessCode {
     DELETE_SUCCESS(200, "200", "데이터 삭제 성공"),
     INSERT_SUCCESS(201, "201", "데이터 삽입 성공"),
     UPDATE_SUCCESS(204, "204", "데이터 수정 성공"),
+    ROLLBACK_SUCCESS(200, "200", "데이터 롤백 저장 성공"),
 
     ;
 

--- a/src/main/java/com/lit_map_BackEnd/domain/character/entity/RollBackCast.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/character/entity/RollBackCast.java
@@ -1,0 +1,46 @@
+package com.lit_map_BackEnd.domain.character.entity;
+
+import com.lit_map_BackEnd.domain.work.entity.RollBackVersion;
+import com.lit_map_BackEnd.domain.work.entity.Version;
+import com.lit_map_BackEnd.domain.work.entity.Work;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "rollback_casts")
+public class RollBackCast {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "work_id")
+    private Work work;
+
+    @ManyToOne
+    @JoinColumn(name = "rollback_version_id")
+    private RollBackVersion rollBackVersion;
+
+    private String imageUrl;
+
+    private String name;
+
+    private String role;
+
+    private String type;
+
+    private String gender;
+    private int age;
+    private String mbti;
+
+    @Lob
+    private String contents;
+
+    public void changeRollBackVersion(RollBackVersion rollBackVersion) {
+        this.rollBackVersion = rollBackVersion;
+    }
+}

--- a/src/main/java/com/lit_map_BackEnd/domain/character/service/CastService.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/character/service/CastService.java
@@ -4,6 +4,7 @@ package com.lit_map_BackEnd.domain.character.service;
 import com.lit_map_BackEnd.domain.character.dto.CastRequestDto;
 import com.lit_map_BackEnd.domain.character.dto.CastResponseDto;
 import com.lit_map_BackEnd.domain.character.entity.Cast;
+import com.lit_map_BackEnd.domain.character.entity.RollBackCast;
 import com.lit_map_BackEnd.domain.work.entity.Work;
 
 import java.util.List;
@@ -14,4 +15,6 @@ public interface CastService {
     List<CastResponseDto> findCharacterByWork(Work work);
 
     void deleteCastInVersion(Long workId, Double versionId, String name);
+
+    RollBackCast insertRollBackCast(Cast cast);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/character/service/CastServiceImpl.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/character/service/CastServiceImpl.java
@@ -5,6 +5,7 @@ import com.lit_map_BackEnd.common.exception.code.ErrorCode;
 import com.lit_map_BackEnd.domain.character.dto.CastRequestDto;
 import com.lit_map_BackEnd.domain.character.dto.CastResponseDto;
 import com.lit_map_BackEnd.domain.character.entity.Cast;
+import com.lit_map_BackEnd.domain.character.entity.RollBackCast;
 import com.lit_map_BackEnd.domain.character.repository.CastRepository;
 import com.lit_map_BackEnd.domain.work.entity.Version;
 import com.lit_map_BackEnd.domain.work.entity.Work;
@@ -92,5 +93,20 @@ public class CastServiceImpl implements CastService {
         }
 
         castRepository.deleteByWorkAndVersionAndName(work, version, name);
+    }
+
+    @Override
+    public RollBackCast insertRollBackCast(Cast cast) {
+        return RollBackCast.builder()
+                .work(cast.getWork())
+                .imageUrl(cast.getImageUrl())
+                .name(cast.getName())
+                .role(cast.getRole())
+                .type(cast.getType())
+                .gender(cast.getGender())
+                .age(cast.getAge())
+                .mbti(cast.getMbti())
+                .contents(cast.getContents())
+                .build();
     }
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/controller/VersionController.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/controller/VersionController.java
@@ -7,10 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/version")
@@ -29,6 +26,23 @@ public class VersionController {
                 .result("성공")
                 .resultCode(SuccessCode.DELETE_SUCCESS.getStatus())
                 .resultMsg(SuccessCode.DELETE_SUCCESS.getMessage())
+                .build();
+
+        return new ResponseEntity<>(res, HttpStatus.OK);
+    }
+
+    @PutMapping("/rollback/{workId}/{versionNum}")
+    @Operation(summary = "버전 수정으로 인한 롤백데이터 저장", description = "버전을 수정하면서 기존의 데이터를 롤백 테이블에 데이터 기입")
+    public ResponseEntity<SuccessResponse> updateVersion(@PathVariable Long workId,
+                                                         @PathVariable Double versionNum) {
+        // 롤백 테이블에 데이터 저장
+
+        versionService.rollBackDataSave(workId, versionNum);
+
+        SuccessResponse res = SuccessResponse.builder()
+                .result("롤백 데이터 저장 완료")
+                .resultCode(SuccessCode.ROLLBACK_SUCCESS.getStatus())
+                .resultMsg(SuccessCode.ROLLBACK_SUCCESS.getMessage())
                 .build();
 
         return new ResponseEntity<>(res, HttpStatus.OK);

--- a/src/main/java/com/lit_map_BackEnd/domain/work/controller/WorkController.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/controller/WorkController.java
@@ -39,7 +39,7 @@ public class WorkController {
     }
 
     @GetMapping("/{id}/{versionNum}")
-    @Operation(summary = "수정, 추가를 위한 특정 버전 가져오기", description = "수정과 추가를 하기 위해 작품의 특정 버전의 정보를 가져오는 API")
+    @Operation(summary = "특정 버전 가져오기", description = "수정과 추가를 하기 위해 작품의 특정 버전의 정보를 가져오는 API")
     public ResponseEntity<SuccessResponse> getWorkVersion(@PathVariable Long id,
                                                           @PathVariable Double versionNum) {
         // 해당 작품의 특정 버전 정보 가져오기 ( 전체데이터 or 해당 버전의 내용 )
@@ -76,7 +76,7 @@ public class WorkController {
         SuccessResponse res = SuccessResponse.builder()
                 .result("성공")
                 .resultCode(SuccessCode.DELETE_SUCCESS.getStatus())
-                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
+                .resultMsg(SuccessCode.DELETE_SUCCESS.getMessage())
                 .build();
 
         return new ResponseEntity<>(res, HttpStatus.OK);

--- a/src/main/java/com/lit_map_BackEnd/domain/work/dto/VersionListDto.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/dto/VersionListDto.java
@@ -9,7 +9,12 @@ import lombok.Data;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class VersionListDto {
+public class VersionListDto implements Comparable<VersionListDto>{
     private Double versionNum;
     private String versionName;
+
+    @Override
+    public int compareTo(VersionListDto o) {
+        return (int) ((this.getVersionNum() * 10) - (o.getVersionNum() * 10));
+    }
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/entity/RollBackVersion.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/entity/RollBackVersion.java
@@ -1,0 +1,42 @@
+package com.lit_map_BackEnd.domain.work.entity;
+
+import com.lit_map_BackEnd.common.converter.JsonMapConverter;
+import com.lit_map_BackEnd.domain.character.entity.Cast;
+import com.lit_map_BackEnd.domain.character.entity.RollBackCast;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "rollback_versions")
+public class RollBackVersion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "work_id")
+    private Work work;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "rollBackVersion", cascade = CascadeType.ALL)
+    private List<RollBackCast> casts = new ArrayList<>();
+
+    private Double versionNum;
+    private String versionName;
+
+    @Convert(converter = JsonMapConverter.class)
+    @Column(name = "relationship", columnDefinition = "json")
+    private Map<String, Object> relationship;
+
+    @Enumerated(EnumType.STRING)
+    private Confirm confirm;
+}

--- a/src/main/java/com/lit_map_BackEnd/domain/work/entity/Work.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/entity/Work.java
@@ -60,6 +60,10 @@ public class Work extends BaseTimeEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "work", cascade = CascadeType.ALL)
+    private List<RollBackVersion> rollBackVersions = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "work", cascade = CascadeType.ALL)
     private List<Cast> casts = new ArrayList<>();
 
     private int view;

--- a/src/main/java/com/lit_map_BackEnd/domain/work/repository/RollBackVersionRepository.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/repository/RollBackVersionRepository.java
@@ -3,11 +3,18 @@ package com.lit_map_BackEnd.domain.work.repository;
 import com.lit_map_BackEnd.domain.work.entity.RollBackVersion;
 import com.lit_map_BackEnd.domain.work.entity.Work;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface RollBackVersionRepository extends JpaRepository<RollBackVersion, Long> {
     boolean existsByWorkAndVersionNum(Work work, Double versionNum);
 
     void deleteRollBackVersionByWorkAndVersionNum(Work work, Double versionNum);
+
+    @Query("select rv from RollBackVersion rv where rv.work = :work and rv.confirm = 'COMPLETE'")
+    List<RollBackVersion> findByWork(@Param("work") Work work);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/repository/RollBackVersionRepository.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/repository/RollBackVersionRepository.java
@@ -1,0 +1,13 @@
+package com.lit_map_BackEnd.domain.work.repository;
+
+import com.lit_map_BackEnd.domain.work.entity.RollBackVersion;
+import com.lit_map_BackEnd.domain.work.entity.Work;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RollBackVersionRepository extends JpaRepository<RollBackVersion, Long> {
+    boolean existsByWorkAndVersionNum(Work work, Double versionNum);
+
+    void deleteRollBackVersionByWorkAndVersionNum(Work work, Double versionNum);
+}

--- a/src/main/java/com/lit_map_BackEnd/domain/work/repository/VersionRepository.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/repository/VersionRepository.java
@@ -5,6 +5,7 @@ import com.lit_map_BackEnd.domain.work.entity.Version;
 import com.lit_map_BackEnd.domain.work.entity.Work;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Map;
@@ -14,7 +15,8 @@ public interface VersionRepository extends JpaRepository<Version, Long> {
 
     boolean existsByVersionNumAndWork(Double version, Work work);
 
-    List<Version> findByWork(Work work);
+    @Query("select v from Version v where v.work = :work and v.confirm = 'COMPLETE'")
+    List<Version> findByWork(@Param("work")Work work);
 
     void deleteByWorkAndVersionNum(Work work, Double versionNum);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionService.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionService.java
@@ -18,4 +18,6 @@ public interface VersionService {
     void deleteVersion(Long workId, Double versionNum);
 
     List<VersionListDto> versionList(Work work);
+
+    int rollBackDataSave(Long workId, Double versionNum);
 }

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionServiceImpl.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionServiceImpl.java
@@ -20,9 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -90,20 +88,35 @@ public class VersionServiceImpl implements VersionService{
     public List<VersionListDto> versionList(Work work) {
         // complete 된것만 가져오기
         List<Version> versions = versionRepository.findByWork(work);
+        List<RollBackVersion> rollBackVersions = rollBackVersionRepository.findByWork(work);
 
         List<VersionListDto> list = new ArrayList<>();
+        for (Version version : versions) {
+            VersionListDto build = VersionListDto.builder()
+                    .versionNum(version.getVersionNum())
+                    .versionName(version.getVersionName())
+                    .build();
 
-        List<VersionListDto> collect = versions.stream().map(version -> VersionListDto.builder()
-                        .versionNum(version.getVersionNum())
-                        .versionName(version.getVersionName())
-                        .build())
-                        .toList();
+            list.add(build);
+        }
 
-        for (VersionListDto versionListDto : collect) {
+        for (RollBackVersion rollBackVersion : rollBackVersions) {
+            VersionListDto build = VersionListDto.builder()
+                    .versionNum(rollBackVersion.getVersionNum())
+                    .versionName(rollBackVersion.getVersionName())
+                    .build();
+
+            list.add(build);
+        }
+
+        // versionListDto 에 Comparable을 구현하여 순서 정리
+        Collections.sort(list);
+
+        for (VersionListDto versionListDto : list) {
             System.out.println("name = " + versionListDto.getVersionName());
             System.out.println("num = " + versionListDto.getVersionNum());
         }
-        return collect;
+        return list;
     }
 
     @Override

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionServiceImpl.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/VersionServiceImpl.java
@@ -3,18 +3,24 @@ package com.lit_map_BackEnd.domain.work.service;
 import com.lit_map_BackEnd.common.exception.BusinessExceptionHandler;
 import com.lit_map_BackEnd.common.exception.code.ErrorCode;
 import com.lit_map_BackEnd.domain.character.dto.CastResponseDto;
+import com.lit_map_BackEnd.domain.character.entity.Cast;
+import com.lit_map_BackEnd.domain.character.entity.RollBackCast;
 import com.lit_map_BackEnd.domain.character.repository.CastRepository;
+import com.lit_map_BackEnd.domain.character.service.CastService;
 import com.lit_map_BackEnd.domain.work.dto.VersionListDto;
 import com.lit_map_BackEnd.domain.work.dto.VersionResponseDto;
+import com.lit_map_BackEnd.domain.work.entity.Confirm;
+import com.lit_map_BackEnd.domain.work.entity.RollBackVersion;
 import com.lit_map_BackEnd.domain.work.entity.Version;
 import com.lit_map_BackEnd.domain.work.entity.Work;
+import com.lit_map_BackEnd.domain.work.repository.RollBackVersionRepository;
 import com.lit_map_BackEnd.domain.work.repository.VersionRepository;
 import com.lit_map_BackEnd.domain.work.repository.WorkRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -26,6 +32,8 @@ public class VersionServiceImpl implements VersionService{
     private final VersionRepository versionRepository;
     private final WorkRepository workRepository;
     private final CastRepository castRepository;
+    private final RollBackVersionRepository rollBackVersionRepository;
+    private final CastService castService;
 
     // 기존의 버전 정보 업데이트하기
     @Override
@@ -80,7 +88,10 @@ public class VersionServiceImpl implements VersionService{
 
     @Override
     public List<VersionListDto> versionList(Work work) {
+        // complete 된것만 가져오기
         List<Version> versions = versionRepository.findByWork(work);
+
+        List<VersionListDto> list = new ArrayList<>();
 
         List<VersionListDto> collect = versions.stream().map(version -> VersionListDto.builder()
                         .versionNum(version.getVersionNum())
@@ -93,6 +104,47 @@ public class VersionServiceImpl implements VersionService{
             System.out.println("num = " + versionListDto.getVersionNum());
         }
         return collect;
+    }
+
+    @Override
+    @Transactional
+    public int rollBackDataSave(Long workId, Double versionNum) {
+        Work work = workRepository.findById(workId)
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.WORK_NOT_FOUND));
+        Version version = versionRepository.findByVersionNumAndWork(versionNum, work);
+
+        // 수정을 누를때마다 기존의 롤백 데이터는 삭제
+        if (rollBackVersionRepository.existsByWorkAndVersionNum(work, versionNum)) {
+            rollBackVersionRepository.deleteRollBackVersionByWorkAndVersionNum(work, versionNum);
+        }
+
+        // 롤백 데이터 버전 저장
+        RollBackVersion rollBackVersion = RollBackVersion.builder()
+                .work(version.getWork())
+                .versionName(version.getVersionName())
+                .versionNum(version.getVersionNum())
+                .confirm(version.getConfirm())
+                .relationship(version.getRelationship())
+                .build();
+
+        // 해당 버전의 연결된 캐릭터 받아오기
+        List<Cast> casts = version.getCasts();
+
+        // 받아온 캐릭터 RollBackCast에 저장
+        for (Cast cast : casts) {
+            // 각 캐릭터를 저장하고 rollbackversion에 연결시킨다.
+            RollBackCast rollBackCast = castService.insertRollBackCast(cast);
+            rollBackCast.changeRollBackVersion(rollBackVersion);
+            rollBackVersion.getCasts().add(rollBackCast);
+        }
+
+        // work 에 롤백 데이터가 들어갈때 같이 들어가야함 -> 삭제 될때 같이 삭제 되어야 한다.
+        work.getRollBackVersions().add(rollBackVersion);
+        // 기존 데이터는 다시 승인 전으로 돌리기
+        version.confirmSetting(Confirm.LOAD);
+
+        rollBackVersionRepository.save(rollBackVersion);
+        return 1;
     }
 
 

--- a/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkServiceImpl.java
+++ b/src/main/java/com/lit_map_BackEnd/domain/work/service/WorkServiceImpl.java
@@ -188,6 +188,7 @@ public class WorkServiceImpl implements WorkService{
         return 1;
     }
 
+    // 작품 상세 내용 가져오기 ( 승인이 완료된 내용만 가져오기 )
     @Override
     public WorkResponseDto getWork(Long workId) {
         // 이미지, 작성자, 출판사, 제목, 설명 겸 작품 ID 검사
@@ -222,12 +223,6 @@ public class WorkServiceImpl implements WorkService{
             String name = workAuthor.getAuthor().getName();
             workAuthorsList.add(name);
         }
-
-        // 캐릭터
-        //List<CastResponseDto> characterByWork = castService.findCharacterByWork(work);
-
-        // 버전 정보 및 내용
-        //List<VersionResponseDto> versionByWork = versionService.findVersionByWork(work);
 
         // 기존의 작품의 버전 관련된 내용을 전부 가져오는 과정에서 그냥 0.1버전 하나만 가져오는 것으로 변경
         // 이는 초기 로딩 속도와 네트워크 효율성을 고려하여 제작


### PR DESCRIPTION
롤백 테이블을 만들고 이제 수정을 하면 수정 전의 기록은 롤백테이블로 전달하고 수정된 데이터를 지우고 기존의 데이터를 가져올떄는 롤백 데이터를 통해 데이터를 롤백한다

하지만 수정하는 동안 기록된 데이터를 볼 수 있어야 하기 때문에 작품의 상세 검색을 할때 두개의 테이블을 모두 살펴야 한다.